### PR TITLE
chore: adhere to PEP 585 and removed unused imports

### DIFF
--- a/src/llama_index_cloud_sql_pg/async_document_store.py
+++ b/src/llama_index_cloud_sql_pg/async_document_store.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Optional, Sequence
 
 from llama_index.core.constants import DATA_KEY
 from llama_index.core.schema import BaseNode
@@ -119,13 +119,13 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         return results
 
     async def _put_all_doc_hashes_to_table(
-        self, rows: List[Tuple[str, str]], batch_size: int = int(DEFAULT_BATCH_SIZE)
+        self, rows: list[tuple[str, str]], batch_size: int = int(DEFAULT_BATCH_SIZE)
     ) -> None:
         """Puts a multiple rows of node ids with their doc_hash into the document table.
         Incase a row with the id already exists, it updates the row with the new doc_hash.
 
         Args:
-            rows (List[Tuple[str, str]]): List of tuples of id and doc_hash
+            rows (list[tuple[str, str]]): List of tuples of id and doc_hash
             batch_size (int): batch_size to insert the rows. Defaults to 1.
 
         Returns:
@@ -173,7 +173,7 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         """Adds a document to the store.
 
         Args:
-            docs (List[BaseDocument]): documents
+            docs (list[BaseDocument]): documents
             allow_update (bool): allow update of docstore from document
             batch_size (int): batch_size to insert the rows. Defaults to 1.
             store_text (bool): allow the text content of the node to stored.
@@ -225,11 +225,11 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
             await self.__aexecute_query(query, batch)
 
     @property
-    async def adocs(self) -> Dict[str, BaseNode]:
+    async def adocs(self) -> dict[str, BaseNode]:
         """Get all documents.
 
         Returns:
-            Dict[str, BaseDocument]: documents
+            dict[str, BaseDocument]: documents
         """
         query = f"""SELECT * from "{self._schema_name}"."{self._table_name}";"""
         list_docs = await self.__afetch_query(query)
@@ -300,12 +300,12 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
 
         return RefDocInfo(node_ids=node_ids, metadata=merged_metadata)
 
-    async def aget_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+    async def aget_all_ref_doc_info(self) -> Optional[dict[str, RefDocInfo]]:
         """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents.
 
         Returns:
             Optional[
-              Dict[
+              dict[
                 str,          #Ref_doc_id
                 RefDocInfo,   #Ref_doc_info of the id
               ]
@@ -356,14 +356,14 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
 
     async def _get_ref_doc_child_node_ids(
         self, ref_doc_id: str
-    ) -> Optional[Dict[str, List[str]]]:
+    ) -> Optional[dict[str, list[str]]]:
         """Helper function to find the child node mappings of a ref_doc_id.
 
         Returns:
             Optional[
-              Dict[
+              dict[
                 str,    # Ref_doc_id
-                List    # List of all nodes that refer to ref_doc_id
+                list    # List of all nodes that refer to ref_doc_id
               ]
             ]"""
         query = f"""select id from "{self._schema_name}"."{self._table_name}" where ref_doc_id = '{ref_doc_id}';"""
@@ -442,11 +442,11 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
 
         await self._put_all_doc_hashes_to_table(rows=[(doc_id, doc_hash)])
 
-    async def aset_document_hashes(self, doc_hashes: Dict[str, str]) -> None:
+    async def aset_document_hashes(self, doc_hashes: dict[str, str]) -> None:
         """Set the hash for a given doc_id.
 
         Args:
-            doc_hashes (Dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
+            doc_hashes (dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
 
         Returns:
             None
@@ -473,11 +473,11 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         else:
             return None
 
-    async def aget_all_document_hashes(self) -> Dict[str, str]:
+    async def aget_all_document_hashes(self) -> dict[str, str]:
         """Get the stored hash for all documents.
 
         Returns:
-            Dict[
+            dict[
               str,   # doc_hash
               str    # doc_id
             ]
@@ -498,11 +498,11 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         return hashes
 
     @property
-    def docs(self) -> Dict[str, BaseNode]:
+    def docs(self) -> dict[str, BaseNode]:
         """Get all documents.
 
         Returns:
-            Dict[str, BaseDocument]: documents
+            dict[str, BaseDocument]: documents
 
         """
         raise NotImplementedError(
@@ -547,7 +547,7 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
             "Sync methods are not implemented for AsyncPostgresDocumentStore. Use PostgresDocumentStore  interface instead."
         )
 
-    def set_document_hashes(self, doc_hashes: Dict[str, str]) -> None:
+    def set_document_hashes(self, doc_hashes: dict[str, str]) -> None:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresDocumentStore. Use PostgresDocumentStore  interface instead."
         )
@@ -557,12 +557,12 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
             "Sync methods are not implemented for AsyncPostgresDocumentStore. Use PostgresDocumentStore  interface instead."
         )
 
-    def get_all_document_hashes(self) -> Dict[str, str]:
+    def get_all_document_hashes(self) -> dict[str, str]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresDocumentStore. Use PostgresDocumentStore  interface instead."
         )
 
-    def get_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+    def get_all_ref_doc_info(self) -> Optional[dict[str, RefDocInfo]]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresDocumentStore. Use PostgresDocumentStore  interface instead."
         )

--- a/src/llama_index_cloud_sql_pg/async_index_store.py
+++ b/src/llama_index_cloud_sql_pg/async_index_store.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import List, Optional
+from typing import Optional
 
-from llama_index.core.constants import DATA_KEY
 from llama_index.core.data_structs.data_structs import IndexStruct
 from llama_index.core.storage.index_store.types import BaseIndexStore
 from llama_index.core.storage.index_store.utils import (
@@ -113,11 +112,11 @@ class AsyncPostgresIndexStore(BaseIndexStore):
             await conn.commit()
         return results
 
-    async def aindex_structs(self) -> List[IndexStruct]:
+    async def aindex_structs(self) -> list[IndexStruct]:
         """Get all index structs.
 
         Returns:
-            List[IndexStruct]: index structs
+            list[IndexStruct]: index structs
 
         """
         query = f"""SELECT * from "{self._schema_name}"."{self._table_name}";"""
@@ -190,7 +189,7 @@ class AsyncPostgresIndexStore(BaseIndexStore):
                 return json_to_index_struct(index_data)
             return None
 
-    def index_structs(self) -> List[IndexStruct]:
+    def index_structs(self) -> list[IndexStruct]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
         )

--- a/src/llama_index_cloud_sql_pg/async_vector_store.py
+++ b/src/llama_index_cloud_sql_pg/async_vector_store.py
@@ -15,14 +15,10 @@
 # TODO: Remove below import when minimum supported Python version is 3.10
 from __future__ import annotations
 
-import base64
 import json
-import re
-import uuid
 import warnings
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type
+from typing import Any, Optional, Sequence
 
-import numpy as np
 from llama_index.core.schema import BaseNode, MetadataMode, NodeRelationship, TextNode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
@@ -31,7 +27,6 @@ from llama_index.core.vector_stores.types import (
     MetadataFilter,
     MetadataFilters,
     VectorStoreQuery,
-    VectorStoreQueryMode,
     VectorStoreQueryResult,
 )
 from llama_index.core.vector_stores.utils import (
@@ -70,7 +65,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -88,7 +83,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -120,7 +115,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     @classmethod
     async def create(
-        cls: Type[AsyncPostgresVectorStore],
+        cls: type[AsyncPostgresVectorStore],
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
@@ -128,7 +123,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -146,7 +141,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -233,7 +228,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         """Get client."""
         return self._engine
 
-    async def async_add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> List[str]:
+    async def async_add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> list[str]:
         """Asynchronously add nodes to the table."""
         ids = []
         metadata_col_names = (
@@ -292,14 +287,14 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     async def adelete_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
         **delete_kwargs: Any,
     ) -> None:
         """Asynchronously delete a set of nodes from the table matching the provided nodes and filters."""
         if not node_ids and not filters:
             return
-        all_filters: List[MetadataFilter | MetadataFilters] = []
+        all_filters: list[MetadataFilter | MetadataFilters] = []
         if node_ids:
             all_filters.append(
                 MetadataFilter(
@@ -331,9 +326,9 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     async def aget_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
-    ) -> List[BaseNode]:
+    ) -> list[BaseNode]:
         """Asynchronously get nodes from the table matching the provided nodes and filters."""
         query = VectorStoreQuery(
             node_ids=node_ids, filters=filters, similarity_top_k=-1
@@ -365,7 +360,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
                 similarities.append(row["distance"])
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
 
-    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> List[str]:
+    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> list[str]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
@@ -377,7 +372,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     def delete_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
         **delete_kwargs: Any,
     ) -> None:
@@ -392,9 +387,9 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     def get_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
-    ) -> List[BaseNode]:
+    ) -> list[BaseNode]:
         raise NotImplementedError(
             "Sync methods are not implemented for AsyncPostgresVectorStore. Use PostgresVectorStore interface instead."
         )
@@ -486,7 +481,7 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         **kwargs: Any,
     ) -> Sequence[RowMapping]:
         """Perform search query on database."""
-        filters: List[MetadataFilter | MetadataFilters] = []
+        filters: list[MetadataFilter | MetadataFilters] = []
         if query.doc_ids:
             filters.append(
                 MetadataFilter(

--- a/src/llama_index_cloud_sql_pg/document_store.py
+++ b/src/llama_index_cloud_sql_pg/document_store.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence, Type
+from typing import Optional, Sequence
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.storage.docstore import BaseDocumentStore
@@ -55,7 +55,7 @@ class PostgresDocumentStore(BaseDocumentStore):
 
     @classmethod
     async def create(
-        cls: Type[PostgresDocumentStore],
+        cls: type[PostgresDocumentStore],
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
@@ -83,7 +83,7 @@ class PostgresDocumentStore(BaseDocumentStore):
 
     @classmethod
     def create_sync(
-        cls: Type[PostgresDocumentStore],
+        cls: type[PostgresDocumentStore],
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
@@ -110,11 +110,11 @@ class PostgresDocumentStore(BaseDocumentStore):
         return cls(cls.__create_key, engine, document_store)
 
     @property
-    def docs(self) -> Dict[str, BaseNode]:
+    def docs(self) -> dict[str, BaseNode]:
         """Get all documents.
 
         Returns:
-            Dict[str, BaseDocument]: documents
+            dict[str, BaseDocument]: documents
 
         """
         return self._engine._run_as_sync(self.__document_store.adocs)
@@ -291,11 +291,11 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aset_document_hash(doc_id, doc_hash)
         )
 
-    async def aset_document_hashes(self, doc_hashes: Dict[str, str]) -> None:
+    async def aset_document_hashes(self, doc_hashes: dict[str, str]) -> None:
         """Set the hash for a given doc_id.
 
         Args:
-            doc_hashes (Dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
+            doc_hashes (dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
 
         Returns:
             None
@@ -304,11 +304,11 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aset_document_hashes(doc_hashes)
         )
 
-    def set_document_hashes(self, doc_hashes: Dict[str, str]) -> None:
+    def set_document_hashes(self, doc_hashes: dict[str, str]) -> None:
         """Set the hash for a given doc_id.
 
         Args:
-            doc_hashes (Dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
+            doc_hashes (dict[str, str]): Dictionary with doc_id as key and doc_hash as value.
 
         Returns:
             None
@@ -343,11 +343,11 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aget_document_hash(doc_id)
         )
 
-    async def aget_all_document_hashes(self) -> Dict[str, str]:
+    async def aget_all_document_hashes(self) -> dict[str, str]:
         """Get the stored hash for all documents.
 
         Returns:
-            Dict[
+            dict[
               str,   # doc_hash
               str    # doc_id
             ]
@@ -356,11 +356,11 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aget_all_document_hashes()
         )
 
-    def get_all_document_hashes(self) -> Dict[str, str]:
+    def get_all_document_hashes(self) -> dict[str, str]:
         """Get the stored hash for all documents.
 
         Returns:
-            Dict[
+            dict[
               str,   # doc_hash
               str    # doc_id
             ]
@@ -369,12 +369,12 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aget_all_document_hashes()
         )
 
-    async def aget_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+    async def aget_all_ref_doc_info(self) -> Optional[dict[str, RefDocInfo]]:
         """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents.
 
         Returns:
             Optional[
-              Dict[
+              dict[
                 str,          #Ref_doc_id
                 RefDocInfo,   #Ref_doc_info of the id
               ]
@@ -384,12 +384,12 @@ class PostgresDocumentStore(BaseDocumentStore):
             self.__document_store.aget_all_ref_doc_info()
         )
 
-    def get_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+    def get_all_ref_doc_info(self) -> Optional[dict[str, RefDocInfo]]:
         """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents.
 
         Returns:
             Optional[
-              Dict[
+              dict[
                 str,          #Ref_doc_id
                 RefDocInfo,   #Ref_doc_info of the id
               ]

--- a/src/llama_index_cloud_sql_pg/engine.py
+++ b/src/llama_index_cloud_sql_pg/engine.py
@@ -21,10 +21,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Awaitable,
-    Dict,
-    List,
     Optional,
-    Type,
     TypeVar,
     Union,
 )
@@ -75,7 +72,7 @@ async def _get_iam_principal_email(
     url = f"https://oauth2.googleapis.com/tokeninfo?access_token={credentials.token}"
     async with aiohttp.ClientSession() as client:
         response = await client.get(url, raise_for_status=True)
-        response_json: Dict = await response.json()
+        response_json: dict = await response.json()
         email = response_json.get("email")
     if email is None:
         raise ValueError(
@@ -511,7 +508,7 @@ class PostgresEngine:
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -527,7 +524,7 @@ class PostgresEngine:
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -584,7 +581,7 @@ class PostgresEngine:
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -600,7 +597,7 @@ class PostgresEngine:
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -635,7 +632,7 @@ class PostgresEngine:
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[Column] = [],
+        metadata_columns: list[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -651,7 +648,7 @@ class PostgresEngine:
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".

--- a/src/llama_index_cloud_sql_pg/engine.py
+++ b/src/llama_index_cloud_sql_pg/engine.py
@@ -17,14 +17,7 @@ import asyncio
 from concurrent.futures import Future
 from dataclasses import dataclass
 from threading import Thread
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Awaitable, Optional, TypeVar, Union
 
 import aiohttp
 import google.auth  # type: ignore

--- a/src/llama_index_cloud_sql_pg/index_store.py
+++ b/src/llama_index_cloud_sql_pg/index_store.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 
 from llama_index.core.data_structs.data_structs import IndexStruct
 from llama_index.core.storage.index_store.types import BaseIndexStore
@@ -96,20 +96,20 @@ class PostgresIndexStore(BaseIndexStore):
         index_store = engine._run_as_sync(coro)
         return cls(cls.__create_key, engine, index_store)
 
-    async def aindex_structs(self) -> List[IndexStruct]:
+    async def aindex_structs(self) -> list[IndexStruct]:
         """Get all index structs.
 
         Returns:
-            List[IndexStruct]: index structs
+            list[IndexStruct]: index structs
 
         """
         return await self._engine._run_as_async(self.__index_store.aindex_structs())
 
-    def index_structs(self) -> List[IndexStruct]:
+    def index_structs(self) -> list[IndexStruct]:
         """Get all index structs.
 
         Returns:
-            List[IndexStruct]: index structs
+            list[IndexStruct]: index structs
 
         """
         return self._engine._run_as_sync(self.__index_store.aindex_structs())

--- a/src/llama_index_cloud_sql_pg/indexes.py
+++ b/src/llama_index_cloud_sql_pg/indexes.py
@@ -15,7 +15,7 @@
 import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 
 @dataclass
@@ -44,7 +44,7 @@ class BaseIndex(ABC):
     distance_strategy: DistanceStrategy = field(
         default_factory=lambda: DistanceStrategy.COSINE_DISTANCE
     )
-    partial_indexes: Optional[List[str]] = None
+    partial_indexes: Optional[list[str]] = None
 
     @abstractmethod
     def index_options(self) -> str:

--- a/src/llama_index_cloud_sql_pg/vector_store.py
+++ b/src/llama_index_cloud_sql_pg/vector_store.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Sequence, Type
+from typing import Any, Optional, Sequence
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.vector_stores.types import (
@@ -71,7 +71,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
 
     @classmethod
     async def create(
-        cls: Type[PostgresVectorStore],
+        cls: type[PostgresVectorStore],
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
@@ -79,7 +79,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -97,7 +97,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -138,7 +138,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
 
     @classmethod
     def create_sync(
-        cls: Type[PostgresVectorStore],
+        cls: type[PostgresVectorStore],
         engine: PostgresEngine,
         table_name: str,
         schema_name: str = "public",
@@ -146,7 +146,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
         text_column: str = "text",
         embedding_column: str = "embedding",
         metadata_json_column: str = "li_metadata",
-        metadata_columns: List[str] = [],
+        metadata_columns: list[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
         node_column: str = "node_data",
         stores_text: bool = True,
@@ -164,7 +164,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
             text_column (str): Column that represent text content of a Node. Defaults to "text".
             embedding_column (str): Column for embedding vectors. The embedding is generated from the content of Node. Defaults to "embedding".
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
-            metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
+            metadata_columns (list[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
             node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
@@ -212,11 +212,11 @@ class PostgresVectorStore(BasePydanticVectorStore):
         """Get client."""
         return self._engine
 
-    async def async_add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> List[str]:
+    async def async_add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> list[str]:
         """Asynchronously add nodes to the table."""
         return await self._engine._run_as_async(self.__vs.async_add(nodes, **kwargs))
 
-    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> List[str]:
+    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> list[str]:
         """Synchronously add nodes to the table."""
         return self._engine._run_as_sync(self.__vs.async_add(nodes, **add_kwargs))
 
@@ -230,7 +230,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
 
     async def adelete_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
         **delete_kwargs: Any,
     ) -> None:
@@ -241,7 +241,7 @@ class PostgresVectorStore(BasePydanticVectorStore):
 
     def delete_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
         **delete_kwargs: Any,
     ) -> None:
@@ -260,17 +260,17 @@ class PostgresVectorStore(BasePydanticVectorStore):
 
     async def aget_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
-    ) -> List[BaseNode]:
+    ) -> list[BaseNode]:
         """Asynchronously get nodes from the table matching the provided nodes and filters."""
         return await self._engine._run_as_async(self.__vs.aget_nodes(node_ids, filters))
 
     def get_nodes(
         self,
-        node_ids: Optional[List[str]] = None,
+        node_ids: Optional[list[str]] = None,
         filters: Optional[MetadataFilters] = None,
-    ) -> List[BaseNode]:
+    ) -> list[BaseNode]:
         """Asynchronously get nodes from the table matching the provided nodes and filters."""
         return self._engine._run_as_sync(self.__vs.aget_nodes(node_ids, filters))
 

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -14,7 +14,7 @@
 
 import os
 import uuid
-from typing import List, Sequence
+from typing import Sequence
 
 import pytest
 import pytest_asyncio

--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -15,13 +15,11 @@
 
 import os
 import uuid
-from typing import List, Sequence
 
 import pytest
 import pytest_asyncio
-from llama_index.core.schema import MetadataMode, NodeRelationship, TextNode
+from llama_index.core.schema import TextNode
 from sqlalchemy import text
-from sqlalchemy.engine.row import RowMapping
 
 from llama_index_cloud_sql_pg import PostgresEngine
 from llama_index_cloud_sql_pg.async_vector_store import AsyncPostgresVectorStore

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -14,7 +14,7 @@
 
 import os
 import uuid
-from typing import List, Sequence
+from typing import Sequence
 
 import pytest
 import pytest_asyncio

--- a/tests/test_vector_store_index.py
+++ b/tests/test_vector_store_index.py
@@ -14,16 +14,12 @@
 
 
 import os
-import sys
 import uuid
-from typing import List, Sequence
 
 import pytest
 import pytest_asyncio
-from llama_index.core.schema import MetadataMode, NodeRelationship, TextNode
+from llama_index.core.schema import TextNode
 from sqlalchemy import text
-from sqlalchemy.engine.row import RowMapping
-from sqlalchemy.ext.asyncio import create_async_engine
 
 from llama_index_cloud_sql_pg import PostgresEngine, PostgresVectorStore
 from llama_index_cloud_sql_pg.indexes import (  # type: ignore


### PR DESCRIPTION
As of Python 3.9 and [PEP 585](https://peps.python.org/pep-0585/#implementation) we can use standard collections like
`list`, `dict`, `tuple` for typing instead of the  now deprecated

```python
from typing import Dict, List, Tuple ...
```

Also removing a ton of unused imports.