### PR TITLE
chore: test cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ test = [
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "class"
+
 [tool.black]
 target-version = ['py39']
 

--- a/tests/test_async_chat_store.py
+++ b/tests/test_async_chat_store.py
@@ -92,6 +92,7 @@ class TestAsyncPostgresChatStores:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def chat_store(self, async_engine):

--- a/tests/test_async_document_store.py
+++ b/tests/test_async_document_store.py
@@ -89,6 +89,7 @@ class TestAsyncPostgresDocumentStore:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def doc_store(self, async_engine):

--- a/tests/test_async_index_store.py
+++ b/tests/test_async_index_store.py
@@ -87,6 +87,7 @@ class TestAsyncPostgresIndexStore:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -112,6 +112,7 @@ class TestVectorStore:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_TABLE_CUSTOM_VS}"')
         await engine.close()
+        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -99,6 +99,7 @@ class TestIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
+        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_chat_store.py
+++ b/tests/test_chat_store.py
@@ -96,6 +96,7 @@ class TestPostgresChatStoreAsync:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def async_chat_store(self, async_engine):
@@ -258,6 +259,7 @@ class TestPostgresChatStoreSync:
         yield sync_engine
 
         await sync_engine.close()
+        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def sync_chat_store(self, sync_engine):

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -102,6 +102,7 @@ class TestPostgresDocumentStoreAsync:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def doc_store(self, async_engine):
@@ -387,6 +388,7 @@ class TestPostgresDocumentStoreSync:
         yield sync_engine
 
         await sync_engine.close()
+        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def sync_doc_store(self, sync_engine):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -172,7 +172,6 @@ class TestEngineAsync:
             engine = PostgresEngine.from_engine(engine)
             await aexecute(engine, "SELECT 1")
             await engine.close()
-            await engine._connector.close_async()
 
     async def test_from_connection_string(self, db_name, user, password, host):
         port = "5432"
@@ -356,14 +355,12 @@ class TestEngineSync:
         return get_env_var("IP_ADDRESS", "IP Address for the connection string")
 
     @pytest_asyncio.fixture(scope="class")
-    async def engine(self, db_project, db_region, db_instance, db_name, user, password):
+    async def engine(self, db_project, db_region, db_instance, db_name):
         engine = PostgresEngine.from_instance(
             project_id=db_project,
             instance=db_instance,
             region=db_region,
             database=db_name,
-            user=user,
-            password=password,
         )
         yield engine
         await aexecute(engine, f'DROP TABLE "{DEFAULT_DS_TABLE_SYNC}"')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -117,6 +117,7 @@ class TestEngineAsync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_IS_TABLE}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_CS_TABLE}"')
         await engine.close()
+        await engine._connector.close_async()
 
     async def test_password(
         self,
@@ -171,6 +172,7 @@ class TestEngineAsync:
             engine = PostgresEngine.from_engine(engine)
             await aexecute(engine, "SELECT 1")
             await engine.close()
+            await engine._connector.close_async()
 
     async def test_from_connection_string(self, db_name, user, password, host):
         port = "5432"
@@ -182,12 +184,14 @@ class TestEngineAsync:
         )
         await aexecute(engine, "SELECT 1")
         await engine.close()
+        await engine._connector.close_async()
 
         engine = PostgresEngine.from_engine_args(
             URL.create("postgresql+asyncpg", user, password, host, port, db_name)
         )
         await aexecute(engine, "SELECT 1")
         await engine.close()
+        await engine._connector.close_async()
 
     async def test_from_connection_string_url_error(
         self,
@@ -233,6 +237,7 @@ class TestEngineAsync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
+        await engine._connector.close_async()
 
     async def test_init_document_store(self, engine):
         await engine.ainit_doc_store_table(
@@ -351,12 +356,14 @@ class TestEngineSync:
         return get_env_var("IP_ADDRESS", "IP Address for the connection string")
 
     @pytest_asyncio.fixture(scope="class")
-    async def engine(self, db_project, db_region, db_instance, db_name):
+    async def engine(self, db_project, db_region, db_instance, db_name, user, password):
         engine = PostgresEngine.from_instance(
             project_id=db_project,
             instance=db_instance,
             region=db_region,
             database=db_name,
+            user=user,
+            password=password,
         )
         yield engine
         await aexecute(engine, f'DROP TABLE "{DEFAULT_DS_TABLE_SYNC}"')
@@ -364,6 +371,7 @@ class TestEngineSync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_VS_TABLE_SYNC}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_CS_TABLE_SYNC}"')
         await engine.close()
+        await engine._connector.close_async()
 
     async def test_password(
         self,
@@ -414,6 +422,7 @@ class TestEngineSync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
+        await engine._connector.close_async()
 
     async def test_init_document_store(self, engine):
         engine.init_doc_store_table(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -183,14 +183,12 @@ class TestEngineAsync:
         )
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close_async()
 
         engine = PostgresEngine.from_engine_args(
             URL.create("postgresql+asyncpg", user, password, host, port, db_name)
         )
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close_async()
 
     async def test_from_connection_string_url_error(
         self,

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -96,6 +96,7 @@ class TestPostgresIndexStoreAsync:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):
@@ -209,6 +210,7 @@ class TestPostgresIndexStoreSync:
         yield async_engine
 
         await async_engine.close()
+        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -119,6 +119,7 @@ class TestVectorStoreAsync:
 
         await aexecute(sync_engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await sync_engine.close()
+        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -493,6 +494,7 @@ class TestVectorStoreSync:
 
         await aexecute(sync_engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await sync_engine.close()
+        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_vector_store_index.py
+++ b/tests/test_vector_store_index.py
@@ -108,6 +108,7 @@ class TestIndexSync:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
+        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -198,6 +199,7 @@ class TestAsyncIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE_ASYNC}")
         await engine.close()
+        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):


### PR DESCRIPTION
Following up on PR suggestion from: https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/32

Reviewer points:

1. `await engine._connector.close_async()` seems not required at all instances of `await engine.close()`. 
Example: when added to `test_from_connection_string` [ref](https://github.com/googleapis/llama-index-cloud-sql-pg-python/blob/c65f3913709aada1300b364716872f421c68d5f3/tests/test_engine.py#L184) there's a [failure](https://pantheon.corp.google.com/cloud-build/builds;region=global/ca9715b9-5b4d-46c2-bb52-89cb0ff714ce;step=3?e=13802955&inv=1&invt=Abmv8Q&mods=logs_tg_staging&project=llamaindex-cloud-sql-testing) suggesting:
`'NoneType' object has no attribute 'close_async'`

