### PR TITLE
chore: add drop index statements to avoid conflict

### DIFF
--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -118,6 +118,7 @@ class TestIndex:
         index = HNSWIndex()
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME)
 
     async def test_areindex(self, vs):
         if not await vs.is_valid_index(DEFAULT_INDEX_NAME):
@@ -126,6 +127,7 @@ class TestIndex:
         await vs.areindex()
         await vs.areindex(DEFAULT_INDEX_NAME)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index()
 
     async def test_dropindex(self, vs):
         await vs.adrop_vector_index()
@@ -142,6 +144,7 @@ class TestIndex:
         )
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index("secondindex")
+        await vs.adrop_vector_index()
         await vs.adrop_vector_index("secondindex")
 
     async def test_is_valid_index(self, vs):


### PR DESCRIPTION
Adding delete index statements to avoid `DuplicateTableError: Index already exists` errors.

These got missed as part of https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/37, since they were driven mostly by failing tests.