### PR TITLE
chore: add tests for sync methods in async interfaces

### DIFF
--- a/src/llama_index_cloud_sql_pg/async_chat_store.py
+++ b/src/llama_index_cloud_sql_pg/async_chat_store.py
@@ -261,35 +261,35 @@ class AsyncPostgresChatStore(BaseChatStore):
 
     def set_messages(self, key: str, messages: List[ChatMessage]) -> None:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def get_messages(self, key: str) -> List[ChatMessage]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def add_message(self, key: str, message: ChatMessage) -> None:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def delete_messages(self, key: str) -> Optional[List[ChatMessage]]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def delete_last_message(self, key: str) -> Optional[ChatMessage]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )
 
     def get_keys(self) -> List[str]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
         )

--- a/src/llama_index_cloud_sql_pg/async_index_store.py
+++ b/src/llama_index_cloud_sql_pg/async_index_store.py
@@ -191,22 +191,22 @@ class AsyncPostgresIndexStore(BaseIndexStore):
 
     def index_structs(self) -> list[IndexStruct]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresIndexStore. Use PostgresIndexStore interface instead."
         )
 
     def add_index_struct(self, index_struct: IndexStruct) -> None:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresIndexStore. Use PostgresIndexStore interface instead."
         )
 
     def delete_index_struct(self, key: str) -> None:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresIndexStore. Use PostgresIndexStore interface instead."
         )
 
     def get_index_struct(
         self, struct_id: Optional[str] = None
     ) -> Optional[IndexStruct]:
         raise NotImplementedError(
-            "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
+            "Sync methods are not implemented for AsyncPostgresIndexStore. Use PostgresIndexStore interface instead."
         )

--- a/tests/test_async_chat_store.py
+++ b/tests/test_async_chat_store.py
@@ -25,6 +25,7 @@ from llama_index_cloud_sql_pg import PostgresEngine
 from llama_index_cloud_sql_pg.async_chat_store import AsyncPostgresChatStore
 
 default_table_name_async = "chat_store_" + str(uuid.uuid4())
+sync_method_exception_str = "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore interface instead."
 
 
 async def aexecute(engine: PostgresEngine, query: str) -> None:
@@ -217,3 +218,31 @@ class TestAsyncPostgresChatStores:
 
         assert results[0]["message"] == message_2.dict()
         assert results[1]["message"] == message_3.dict()
+
+    async def test_set_messages(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.set_messages("test_key", [])
+
+    async def test_get_messages(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.get_messages("test_key")
+
+    async def test_add_message(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.add_message("test_key", ChatMessage(content="test", role="user"))
+
+    async def test_delete_messages(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.delete_messages("test_key")
+
+    async def test_delete_message(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.delete_message("test_key", 0)
+
+    async def test_delete_last_message(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.delete_last_message("test_key")
+
+    async def test_get_keys(self, chat_store):
+        with pytest.raises(Exception, match=sync_method_exception_str):
+            chat_store.get_keys()

--- a/tests/test_async_chat_store.py
+++ b/tests/test_async_chat_store.py
@@ -25,7 +25,7 @@ from llama_index_cloud_sql_pg import PostgresEngine
 from llama_index_cloud_sql_pg.async_chat_store import AsyncPostgresChatStore
 
 default_table_name_async = "chat_store_" + str(uuid.uuid4())
-sync_method_exception_str = "Sync methods are not implemented for AsyncPostgresChatStore . Use PostgresChatStore interface instead."
+sync_method_exception_str = "Sync methods are not implemented for AsyncPostgresChatStore. Use PostgresChatStore interface instead."
 
 
 async def aexecute(engine: PostgresEngine, query: str) -> None:

--- a/tests/test_async_index_store.py
+++ b/tests/test_async_index_store.py
@@ -26,7 +26,7 @@ from llama_index_cloud_sql_pg import PostgresEngine
 from llama_index_cloud_sql_pg.async_index_store import AsyncPostgresIndexStore
 
 default_table_name_async = "index_store_" + str(uuid.uuid4())
-sync_method_exception_str = "Sync methods are not implemented for AsyncPostgresIndexStore . Use PostgresIndexStore  interface instead."
+sync_method_exception_str = "Sync methods are not implemented for AsyncPostgresIndexStore. Use PostgresIndexStore interface instead."
 
 
 async def aexecute(engine: PostgresEngine, query: str) -> None:


### PR DESCRIPTION
In an unrelated PR https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/57, test coverage [dropped to <90](https://pantheon.corp.google.com/cloud-build/builds/3327edd4-7ca5-4473-8a6c-38713ae22d8c;step=3?e=13802955&inv=1&invt=AboO6g&mods=logs_tg_staging&project=llamaindex-cloud-sql-testing), so adding some tests to bump it up.

Also contains, nits (improper spacing) on exception messages for sync methods of async interfaces.

