### PR TITLE
chore: Fix warnings in the tests.

### DIFF
--- a/src/llama_index_cloud_sql_pg/async_chat_store.py
+++ b/src/llama_index_cloud_sql_pg/async_chat_store.py
@@ -137,7 +137,7 @@ class AsyncPostgresChatStore(BaseChatStore):
         params = [
             {
                 "key": key,
-                "message": json.dumps(message.dict()),
+                "message": json.dumps(message.model_dump()),
             }
             for message in messages
         ]
@@ -175,7 +175,7 @@ class AsyncPostgresChatStore(BaseChatStore):
         insert_query = f"""
                 INSERT INTO "{self._schema_name}"."{self._table_name}" (key, message)
                 VALUES (:key, :message);"""
-        params = {"key": key, "message": json.dumps(message.dict())}
+        params = {"key": key, "message": json.dumps(message.model_dump())}
 
         await self.__aexecute_query(insert_query, params)
 

--- a/tests/test_async_chat_store.py
+++ b/tests/test_async_chat_store.py
@@ -123,7 +123,7 @@ class TestAsyncPostgresChatStores:
         query = f"""select * from "public"."{default_table_name_async}" where key = '{key}';"""
         results = await afetch(async_engine, query)
         result = results[0]
-        assert result["message"] == message.dict()
+        assert result["message"] == message.model_dump()
 
     async def test_aset_and_aget_messages(self, chat_store):
         message_1 = ChatMessage(content="First message", role="user")
@@ -161,7 +161,7 @@ class TestAsyncPostgresChatStores:
         results = await afetch(async_engine, query)
 
         assert len(results) == 1
-        assert results[0]["message"] == message_1.dict()
+        assert results[0]["message"] == message_1.model_dump()
 
     async def test_adelete_last_message(self, async_engine, chat_store):
         message_1 = ChatMessage(content="Message 1", role="user")
@@ -176,8 +176,8 @@ class TestAsyncPostgresChatStores:
         results = await afetch(async_engine, query)
 
         assert len(results) == 2
-        assert results[0]["message"] == message_1.dict()
-        assert results[1]["message"] == message_2.dict()
+        assert results[0]["message"] == message_1.model_dump()
+        assert results[1]["message"] == message_2.model_dump()
 
     async def test_aget_keys(self, async_engine, chat_store):
         message_1 = [ChatMessage(content="First message", role="user")]
@@ -202,7 +202,7 @@ class TestAsyncPostgresChatStores:
 
         assert len(results) == 1
         result = results[0]
-        assert result["message"] == message_1[0].dict()
+        assert result["message"] == message_1[0].model_dump()
 
         message_2 = ChatMessage(content="Second message", role="user")
         message_3 = ChatMessage(content="Third message", role="user")
@@ -216,8 +216,8 @@ class TestAsyncPostgresChatStores:
         # Assert the previous messages are deleted and only the newest ones exist.
         assert len(results) == 2
 
-        assert results[0]["message"] == message_2.dict()
-        assert results[1]["message"] == message_3.dict()
+        assert results[0]["message"] == message_2.model_dump()
+        assert results[1]["message"] == message_3.model_dump()
 
     async def test_set_messages(self, chat_store):
         with pytest.raises(Exception, match=sync_method_exception_str):

--- a/tests/test_chat_store.py
+++ b/tests/test_chat_store.py
@@ -124,7 +124,7 @@ class TestPostgresChatStoreAsync:
         query = f"""select * from "public"."{default_table_name_async}" where key = '{key}';"""
         results = await afetch(async_engine, query)
         result = results[0]
-        assert result["message"] == message.dict()
+        assert result["message"] == message.model_dump()
 
     async def test_aset_and_aget_messages(self, async_chat_store):
         message_1 = ChatMessage(content="First message", role="user")
@@ -162,7 +162,7 @@ class TestPostgresChatStoreAsync:
         results = await afetch(async_engine, query)
 
         assert len(results) == 1
-        assert results[0]["message"] == message_1.dict()
+        assert results[0]["message"] == message_1.model_dump()
 
     async def test_adelete_last_message(self, async_engine, async_chat_store):
         message_1 = ChatMessage(content="Message 1", role="user")
@@ -177,8 +177,8 @@ class TestPostgresChatStoreAsync:
         results = await afetch(async_engine, query)
 
         assert len(results) == 2
-        assert results[0]["message"] == message_1.dict()
-        assert results[1]["message"] == message_2.dict()
+        assert results[0]["message"] == message_1.model_dump()
+        assert results[1]["message"] == message_2.model_dump()
 
     async def test_aget_keys(self, async_engine, async_chat_store):
         message_1 = [ChatMessage(content="First message", role="user")]
@@ -203,7 +203,7 @@ class TestPostgresChatStoreAsync:
 
         assert len(results) == 1
         result = results[0]
-        assert result["message"] == message_1[0].dict()
+        assert result["message"] == message_1[0].model_dump()
 
         message_2 = ChatMessage(content="Second message", role="user")
         message_3 = ChatMessage(content="Third message", role="user")
@@ -217,8 +217,8 @@ class TestPostgresChatStoreAsync:
         # Assert the previous messages are deleted and only the newest ones exist.
         assert len(results) == 2
 
-        assert results[0]["message"] == message_2.dict()
-        assert results[1]["message"] == message_3.dict()
+        assert results[0]["message"] == message_2.model_dump()
+        assert results[1]["message"] == message_3.model_dump()
 
 
 @pytest.mark.asyncio(loop_scope="class")
@@ -287,7 +287,7 @@ class TestPostgresChatStoreSync:
         query = f"""select * from "public"."{default_table_name_sync}" where key = '{key}';"""
         results = await afetch(sync_engine, query)
         result = results[0]
-        assert result["message"] == message.dict()
+        assert result["message"] == message.model_dump()
 
     async def test_set_and_get_messages(self, sync_chat_store):
         message_1 = ChatMessage(content="First message", role="user")
@@ -325,7 +325,7 @@ class TestPostgresChatStoreSync:
         results = await afetch(sync_engine, query)
 
         assert len(results) == 1
-        assert results[0]["message"] == message_1.dict()
+        assert results[0]["message"] == message_1.model_dump()
 
     async def test_delete_last_message(self, sync_engine, sync_chat_store):
         message_1 = ChatMessage(content="Message 1", role="user")
@@ -340,8 +340,8 @@ class TestPostgresChatStoreSync:
         results = await afetch(sync_engine, query)
 
         assert len(results) == 2
-        assert results[0]["message"] == message_1.dict()
-        assert results[1]["message"] == message_2.dict()
+        assert results[0]["message"] == message_1.model_dump()
+        assert results[1]["message"] == message_2.model_dump()
 
     async def test_get_keys(self, sync_engine, sync_chat_store):
         message_1 = [ChatMessage(content="First message", role="user")]
@@ -366,7 +366,7 @@ class TestPostgresChatStoreSync:
 
         assert len(results) == 1
         result = results[0]
-        assert result["message"] == message_1[0].dict()
+        assert result["message"] == message_1[0].model_dump()
 
         message_2 = ChatMessage(content="Second message", role="user")
         message_3 = ChatMessage(content="Third message", role="user")
@@ -380,5 +380,5 @@ class TestPostgresChatStoreSync:
         # Assert the previous messages are deleted and only the newest ones exist.
         assert len(results) == 2
 
-        assert results[0]["message"] == message_2.dict()
-        assert results[1]["message"] == message_3.dict()
+        assert results[0]["message"] == message_2.model_dump()
+        assert results[1]["message"] == message_3.model_dump()


### PR DESCRIPTION
chore: Fix warnings in the tests.

Change message.dict() to message.model_dump() as the former is deprecated in pydantic v2.