### PR TITLE
chore(docs): update quickstart with missing deps and filepaths

### DIFF
--- a/samples/llama_index_quick_start.ipynb
+++ b/samples/llama_index_quick_start.ipynb
@@ -111,7 +111,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install llama-index-cloud-sql-pg llama-index llama-index-embeddings-vertex llama-index-llms-vertex cloud-sql-python-connector[pg8000]"
+    "%pip install llama-index-cloud-sql-pg llama-index llama-index-embeddings-vertex llama-index-llms-vertex cloud-sql-python-connector[pg8000] pandas"
    ]
   },
   {
@@ -483,7 +483,7 @@
     "    )',\n",
     ")\n",
     "\n",
-    "netflix_data = \"/content/netflix_titles.csv\"\n",
+    "netflix_data = \"netflix_titles.csv\"\n",
     "\n",
     "df = pd.read_csv(netflix_data)\n",
     "insert_data_cmd = sqlalchemy.text(\n",


### PR DESCRIPTION
Borrowing changes from https://github.com/googleapis/llama-index-alloydb-pg-python/pull/90