### PR TITLE
chore(deps): update connectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cloud-sql-python-connector[asyncpg]==1.17.0
+cloud-sql-python-connector[asyncpg]==1.18.1
 llama-index-core==0.12.25
 pgvector==0.4.0
 SQLAlchemy[asyncio]==2.0.39

--- a/tests/test_async_chat_store.py
+++ b/tests/test_async_chat_store.py
@@ -93,7 +93,6 @@ class TestAsyncPostgresChatStores:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def chat_store(self, async_engine):

--- a/tests/test_async_document_store.py
+++ b/tests/test_async_document_store.py
@@ -90,7 +90,6 @@ class TestAsyncPostgresDocumentStore:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def doc_store(self, async_engine):

--- a/tests/test_async_index_store.py
+++ b/tests/test_async_index_store.py
@@ -88,7 +88,6 @@ class TestAsyncPostgresIndexStore:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -113,7 +113,6 @@ class TestVectorStore:
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_CUSTOM_VS}"')
         await engine.close()
-        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -99,7 +99,6 @@ class TestIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
-        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_chat_store.py
+++ b/tests/test_chat_store.py
@@ -96,7 +96,6 @@ class TestPostgresChatStoreAsync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def async_chat_store(self, async_engine):
@@ -259,7 +258,6 @@ class TestPostgresChatStoreSync:
         yield sync_engine
 
         await sync_engine.close()
-        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def sync_chat_store(self, sync_engine):

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -102,7 +102,6 @@ class TestPostgresDocumentStoreAsync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def doc_store(self, async_engine):
@@ -389,7 +388,6 @@ class TestPostgresDocumentStoreSync:
         yield sync_engine
 
         await sync_engine.close()
-        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def sync_doc_store(self, sync_engine):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -118,7 +118,6 @@ class TestEngineAsync:
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_IS_TABLE}"')
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_CS_TABLE}"')
         await engine.close()
-        await engine._connector.close_async()
 
     async def test_password(
         self,
@@ -235,7 +234,6 @@ class TestEngineAsync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close_async()
 
     async def test_init_document_store(self, engine):
         await engine.ainit_doc_store_table(
@@ -367,7 +365,6 @@ class TestEngineSync:
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_VS_TABLE_SYNC}"')
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_CS_TABLE_SYNC}"')
         await engine.close()
-        await engine._connector.close_async()
 
     async def test_init_with_constructor(
         self,
@@ -474,7 +471,6 @@ class TestEngineSync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close_async()
 
     async def test_init_document_store(self, engine):
         engine.init_doc_store_table(

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -96,7 +96,6 @@ class TestPostgresIndexStoreAsync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):
@@ -213,7 +212,6 @@ class TestPostgresIndexStoreSync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -119,7 +119,6 @@ class TestVectorStoreAsync:
 
         await aexecute(sync_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await sync_engine.close()
-        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -495,7 +494,6 @@ class TestVectorStoreSync:
 
         await aexecute(sync_engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await sync_engine.close()
-        await sync_engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_vector_store_index.py
+++ b/tests/test_vector_store_index.py
@@ -108,7 +108,6 @@ class TestIndexSync:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
-        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -199,7 +198,6 @@ class TestAsyncIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE_ASYNC}")
         await engine.close()
-        await engine._connector.close_async()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):


### PR DESCRIPTION
The new version of connectors for Alloy DB are leading to test failures, ref tests in https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/97.

This PR pins the issue to connector's latest version so that other packages can be unblocked from version updates.

In order to fix the issue, changes made in https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/43 had to be reverted.