### PR TITLE
fix: Index store adds interface methods

### DIFF
--- a/src/llama_index_cloud_sql_pg/async_index_store.py
+++ b/src/llama_index_cloud_sql_pg/async_index_store.py
@@ -150,6 +150,20 @@ class AsyncPostgresIndexStore(BaseIndexStore):
         query = insert_query + values_statement + upsert_statement
         await self.__aexecute_query(query, index_row)
 
+    async def async_index_structs(self) -> list[IndexStruct]:
+        """Get all index structs.
+        Returns:
+            list[IndexStruct]: index structs
+        """
+        return await self.aindex_structs()
+
+    async def async_add_index_struct(self, index_struct: IndexStruct) -> None:
+        """Add an index struct.
+        Args:
+            index_struct (IndexStruct): index struct
+        """
+        await self.aadd_index_struct(index_struct)
+
     async def adelete_index_struct(self, key: str) -> None:
         """Delete an index struct.
 

--- a/src/llama_index_cloud_sql_pg/index_store.py
+++ b/src/llama_index_cloud_sql_pg/index_store.py
@@ -96,6 +96,17 @@ class PostgresIndexStore(BaseIndexStore):
         index_store = engine._run_as_sync(coro)
         return cls(cls.__create_key, engine, index_store)
 
+    def add_index_struct(self, index_struct: IndexStruct) -> None:
+        """Add an index struct.
+
+        Args:
+            index_struct (IndexStruct): index struct
+
+        """
+        return self._engine._run_as_sync(
+            self.__index_store.aadd_index_struct(index_struct)
+        )
+
     async def aindex_structs(self) -> list[IndexStruct]:
         """Get all index structs.
 
@@ -125,16 +136,19 @@ class PostgresIndexStore(BaseIndexStore):
             self.__index_store.aadd_index_struct(index_struct)
         )
 
-    def add_index_struct(self, index_struct: IndexStruct) -> None:
-        """Add an index struct.
+    async def async_index_structs(self) -> list[IndexStruct]:
+        """Get all index structs.
+        Returns:
+            list[IndexStruct]: index structs
+        """
+        return await self.aindex_structs()
 
+    async def async_add_index_struct(self, index_struct: IndexStruct) -> None:
+        """Add an index struct.
         Args:
             index_struct (IndexStruct): index struct
-
         """
-        return self._engine._run_as_sync(
-            self.__index_store.aadd_index_struct(index_struct)
-        )
+        await self.aadd_index_struct(index_struct)
 
     async def adelete_index_struct(self, key: str) -> None:
         """Delete an index struct.

--- a/tests/test_async_index_store.py
+++ b/tests/test_async_index_store.py
@@ -147,7 +147,7 @@ class TestAsyncPostgresIndexStore:
         index_graph_struct = IndexGraph()
 
         await index_store.aadd_index_struct(index_dict_struct)
-        await index_store.aadd_index_struct(index_graph_struct)
+        await index_store.async_add_index_struct(index_graph_struct)
         await index_store.aadd_index_struct(index_list_struct)
 
         indexes = await index_store.aindex_structs()

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -149,14 +149,16 @@ class TestPostgresIndexStoreAsync:
         index_graph_struct = IndexGraph()
 
         await index_store.aadd_index_struct(index_dict_struct)
-        await index_store.aadd_index_struct(index_graph_struct)
+        await index_store.async_add_index_struct(index_graph_struct)
         await index_store.aadd_index_struct(index_list_struct)
 
         indexes = await index_store.aindex_structs()
+        indexes_with_async = await index_store.async_index_structs()
 
-        index_store.add_index_struct(index_dict_struct)
-        index_store.add_index_struct(index_graph_struct)
-        index_store.add_index_struct(index_list_struct)
+        assert indexes == indexes_with_async
+        assert index_dict_struct in indexes
+        assert index_list_struct in indexes
+        assert index_graph_struct in indexes
 
     async def test_warning(self, index_store):
         index_dict_struct = IndexDict()
@@ -270,9 +272,9 @@ class TestPostgresIndexStoreSync:
 
         indexes = index_store.index_structs()
 
-        index_store.add_index_struct(index_dict_struct)
-        index_store.add_index_struct(index_graph_struct)
-        index_store.add_index_struct(index_list_struct)
+        assert index_dict_struct in indexes
+        assert index_list_struct in indexes
+        assert index_graph_struct in indexes
 
     async def test_warning(self, index_store):
         index_dict_struct = IndexDict()


### PR DESCRIPTION
Tests in https://github.com/googleapis/llama-index-cloud-sql-pg-python/pull/116 are failing because anew abstract methods were added (`async_index_structs` and `async_add_index_struct`) in `BaseIndexStore`. We already have implementations for those methods, but the new methods diverge from naming scheme of `a<method_name>` and instead do `async_<method_name>` for async methods. So, in this change, the new base methods are mapped using adapter pattern.

This change was added in [llama-index-core v0.12.36](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/storage/index_store/types.py#L18-L28), which show sup on pypi but not yet in llama-index-core's releases history on the GH repo.

## Latest release is still old on GH repo
<img width="286" alt="Screenshot 2025-05-16 at 16 45 41" src="https://github.com/user-attachments/assets/479e284a-0e7f-4690-a263-4cc88ea28df6" />

## Latest release is new on PyPI

<img width="731" alt="Screenshot 2025-05-16 at 16 46 16" src="https://github.com/user-attachments/assets/57e10e25-d3a9-4b68-8219-48d3c201c1ec" />


