### PR TITLE
Refactor: parameterize SQL query values

### DIFF
--- a/src/llama_index_cloud_sql_pg/async_chat_store.py
+++ b/src/llama_index_cloud_sql_pg/async_chat_store.py
@@ -128,9 +128,9 @@ class AsyncPostgresChatStore(BaseChatStore):
             None
 
         """
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = :key; """
-        params = {"key": key}
-        await self.__aexecute_query(query, params)
+        delete_query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = :key; """
+        delete_params = {"key": key}
+        await self.__aexecute_query(delete_query, delete_params)
         insert_query = f"""
                 INSERT INTO "{self._schema_name}"."{self._table_name}" (key, message)
                 VALUES (:key, :message);"""

--- a/src/llama_index_cloud_sql_pg/async_chat_store.py
+++ b/src/llama_index_cloud_sql_pg/async_chat_store.py
@@ -104,9 +104,9 @@ class AsyncPostgresChatStore(BaseChatStore):
             await conn.execute(text(query), params)
             await conn.commit()
 
-    async def __afetch_query(self, query):
+    async def __afetch_query(self, query, params=None):
         async with self._engine.connect() as conn:
-            result = await conn.execute(text(query))
+            result = await conn.execute(text(query), params)
             result_map = result.mappings()
             results = result_map.fetchall()
             await conn.commit()
@@ -128,8 +128,9 @@ class AsyncPostgresChatStore(BaseChatStore):
             None
 
         """
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = '{key}'; """
-        await self.__aexecute_query(query)
+        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = :key; """
+        params = {"key": key}
+        await self.__aexecute_query(query, params)
         insert_query = f"""
                 INSERT INTO "{self._schema_name}"."{self._table_name}" (key, message)
                 VALUES (:key, :message);"""
@@ -154,8 +155,9 @@ class AsyncPostgresChatStore(BaseChatStore):
             List[ChatMessage]: A list of `ChatMessage` objects associated with the provided key.
             If no messages are found, an empty list is returned.
         """
-        query = f"""SELECT message from "{self._schema_name}"."{self._table_name}" WHERE key = '{key}' ORDER BY id;"""
-        results = await self.__afetch_query(query)
+        query = f"""SELECT message from "{self._schema_name}"."{self._table_name}" WHERE key = :key ORDER BY id;"""
+        params = {"key": key}
+        results = await self.__afetch_query(query, params)
         if results:
             return [
                 ChatMessage.model_validate(result.get("message")) for result in results
@@ -189,8 +191,9 @@ class AsyncPostgresChatStore(BaseChatStore):
             Optional[List[ChatMessage]]: A list of `ChatMessage` objects that were deleted, or `None` if no messages
             were associated with the key or could be deleted.
         """
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = '{key}' RETURNING *; """
-        results = await self.__afetch_query(query)
+        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE key = :key RETURNING *; """
+        params = {"key": key}
+        results = await self.__afetch_query(query, params)
         if results:
             return [
                 ChatMessage.model_validate(result.get("message")) for result in results
@@ -208,14 +211,16 @@ class AsyncPostgresChatStore(BaseChatStore):
             Optional[ChatMessage]: The `ChatMessage` object that was deleted, or `None` if no message
             was associated with the key or could be deleted.
         """
-        query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE key = '{key}' ORDER BY id;"""
-        results = await self.__afetch_query(query)
+        query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE key = :key ORDER BY id;"""
+        params = {"key": key}
+        results = await self.__afetch_query(query, params)
         if results:
             if idx >= len(results):
                 return None
             id_to_be_deleted = results[idx].get("id")
-            delete_query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = '{id_to_be_deleted}' RETURNING *;"""
-            result = await self.__afetch_query(delete_query)
+            delete_query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = :id_to_be_deleted RETURNING *;"""
+            delete_params = {"id_to_be_deleted": id_to_be_deleted}
+            result = await self.__afetch_query(delete_query, delete_params)
             result = result[0]
             if result:
                 return ChatMessage.model_validate(result.get("message"))
@@ -232,12 +237,14 @@ class AsyncPostgresChatStore(BaseChatStore):
             Optional[ChatMessage]: The `ChatMessage` object that was deleted, or `None` if no message
             was associated with the key or could be deleted.
         """
-        query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE key = '{key}' ORDER BY id DESC LIMIT 1;"""
-        results = await self.__afetch_query(query)
+        query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE key = :key ORDER BY id DESC LIMIT 1;"""
+        params = {"key": key}
+        results = await self.__afetch_query(query, params)
         if results:
             id_to_be_deleted = results[0].get("id")
-            delete_query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = '{id_to_be_deleted}' RETURNING *;"""
-            result = await self.__afetch_query(delete_query)
+            delete_query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = :id_to_be_deleted RETURNING *;"""
+            delete_params = {"id_to_be_deleted": id_to_be_deleted}
+            result = await self.__afetch_query(delete_query, delete_params)
             result = result[0]
             if result:
                 return ChatMessage.model_validate(result.get("message"))

--- a/src/llama_index_cloud_sql_pg/async_document_store.py
+++ b/src/llama_index_cloud_sql_pg/async_document_store.py
@@ -110,9 +110,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
             await conn.commit()
         return None
 
-    async def __afetch_query(self, query):
+    async def __afetch_query(self, query, params=None):
         async with self._engine.connect() as conn:
-            result = await conn.execute(text(query))
+            result = await conn.execute(text(query), params)
             result_map = result.mappings()
             results = result_map.fetchall()
             await conn.commit()
@@ -159,8 +159,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         Returns:
             List of deleted rows.
         """
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = '{id}' RETURNING *; """
-        result = await self.__afetch_query(query)
+        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE id = :id RETURNING *; """
+        params = {"id": id}
+        result = await self.__afetch_query(query, params)
         return result
 
     async def async_add_documents(
@@ -254,8 +255,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         Returns:
             Optional[BaseNode]: Returns a `BaseNode` object if the document is found
         """
-        query = f"""SELECT node_data from "{self._schema_name}"."{self._table_name}" WHERE id = '{doc_id}';"""
-        result = await self.__afetch_query(query)
+        query = f"""SELECT node_data from "{self._schema_name}"."{self._table_name}" WHERE id = :doc_id;"""
+        params = {"doc_id": doc_id}
+        result = await self.__afetch_query(query, params)
 
         if result:
             result = result[0]
@@ -276,9 +278,10 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         Returns:
             Optional[RefDocInfo]: Returns a `RefDocInfo` object if it exists.
         """
-        query = f"""select id, node_data from "{self._schema_name}"."{self._table_name}" where ref_doc_id = '{ref_doc_id}'"""
+        query = f"""select id, node_data from "{self._schema_name}"."{self._table_name}" where ref_doc_id = :ref_doc_id"""
+        params = {"ref_doc_id": ref_doc_id}
 
-        rows = await self.__afetch_query(query)
+        rows = await self.__afetch_query(query, params)
         node_ids = []
         merged_metadata = {}
 
@@ -350,8 +353,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
         Returns:
             bool : True if document exists in the table.
         """
-        query = f"""SELECT id from "{self._schema_name}"."{self._table_name}" WHERE id = '{doc_id}' LIMIT 1;"""
-        result = await self.__afetch_query(query)
+        query = f"""SELECT id from "{self._schema_name}"."{self._table_name}" WHERE id = :doc_id LIMIT 1;"""
+        params = {"doc_id": doc_id}
+        result = await self.__afetch_query(query, params)
         return bool(result)
 
     async def _get_ref_doc_child_node_ids(
@@ -366,8 +370,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
                 list    # List of all nodes that refer to ref_doc_id
               ]
             ]"""
-        query = f"""select id from "{self._schema_name}"."{self._table_name}" where ref_doc_id = '{ref_doc_id}';"""
-        results = await self.__afetch_query(query)
+        query = f"""select id from "{self._schema_name}"."{self._table_name}" where ref_doc_id = :ref_doc_id;"""
+        params = {"ref_doc_id": ref_doc_id}
+        results = await self.__afetch_query(query, params)
         result = {"node_ids": [item["id"] for item in results]}
         return result
 
@@ -423,7 +428,8 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
                 return
 
         query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE ref_doc_id = :ref_doc_id;"""
-        await self.__aexecute_query(query, {"ref_doc_id": ref_doc_id})
+        params = {"ref_doc_id": ref_doc_id}
+        await self.__aexecute_query(query, params)
 
         await self._delete_from_table(ref_doc_id)
 
@@ -465,8 +471,9 @@ class AsyncPostgresDocumentStore(BaseDocumentStore):
               str   # hash for the given doc_id
             ]
         """
-        query = f"""SELECT id, doc_hash from "{self._schema_name}"."{self._table_name}" WHERE id = '{doc_id}' LIMIT 1;"""
-        row = await self.__afetch_query(query)
+        query = f"""SELECT id, doc_hash from "{self._schema_name}"."{self._table_name}" WHERE id = :doc_id LIMIT 1;"""
+        params = {"doc_id": doc_id}
+        row = await self.__afetch_query(query, params)
 
         if row:
             return row[0].get("doc_hash", None)

--- a/src/llama_index_cloud_sql_pg/async_index_store.py
+++ b/src/llama_index_cloud_sql_pg/async_index_store.py
@@ -104,9 +104,9 @@ class AsyncPostgresIndexStore(BaseIndexStore):
             await conn.execute(text(query), params)
             await conn.commit()
 
-    async def __afetch_query(self, query):
+    async def __afetch_query(self, query, params=None):
         async with self._engine.connect() as conn:
-            result = await conn.execute(text(query))
+            result = await conn.execute(text(query), params)
             result_map = result.mappings()
             results = result_map.fetchall()
             await conn.commit()
@@ -171,8 +171,9 @@ class AsyncPostgresIndexStore(BaseIndexStore):
             key (str): index struct key
 
         """
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE index_id = '{key}'; """
-        await self.__aexecute_query(query)
+        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE index_id = :key; """
+        params = {"key": key}
+        await self.__aexecute_query(query, params)
         return
 
     async def aget_index_struct(
@@ -191,8 +192,9 @@ class AsyncPostgresIndexStore(BaseIndexStore):
             warnings.warn("No struct_id specified and more than one struct exists.")
             return None
         else:
-            query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE index_id = '{struct_id}';"""
-            result = await self.__afetch_query(query)
+            query = f"""SELECT * from "{self._schema_name}"."{self._table_name}" WHERE index_id = :struct_id;"""
+            params = {"struct_id": struct_id}
+            result = await self.__afetch_query(query, params)
             if result:
                 json = result[0]
                 if json is None:

--- a/src/llama_index_cloud_sql_pg/async_vector_store.py
+++ b/src/llama_index_cloud_sql_pg/async_vector_store.py
@@ -471,7 +471,11 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         FROM pg_indexes
         WHERE tablename = :table_name AND schemaname = :schema_name AND indexname = :index_name;
         """
-        params = {"table_name": self._table_name, "schema_name": self._schema_name, "index_name": index_name}
+        params = {
+            "table_name": self._table_name,
+            "schema_name": self._schema_name,
+            "index_name": index_name,
+        }
         async with self._engine.connect() as conn:
             result = await conn.execute(text(query), params)
             result_map = result.mappings()

--- a/src/llama_index_cloud_sql_pg/async_vector_store.py
+++ b/src/llama_index_cloud_sql_pg/async_vector_store.py
@@ -155,9 +155,10 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         Returns:
             AsyncPostgresVectorStore
         """
-        stmt = f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table_name}' AND table_schema = '{schema_name}'"
+        stmt = f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = :table_name AND table_schema = :schema_name"
+        params = {"table_name": table_name, "schema_name": schema_name}
         async with engine._pool.connect() as conn:
-            result = await conn.execute(text(stmt))
+            result = await conn.execute(text(stmt), params)
             result_map = result.mappings()
             results = result_map.fetchall()
         columns = {}
@@ -280,9 +281,10 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
 
     async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """Asynchronously delete nodes belonging to provided parent document from the table."""
-        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE {self._ref_doc_id_column} = '{ref_doc_id}'"""
+        query = f"""DELETE FROM "{self._schema_name}"."{self._table_name}" WHERE {self._ref_doc_id_column} = :ref_doc_id;"""
+        params = {"ref_doc_id": ref_doc_id}
         async with self._engine.connect() as conn:
-            await conn.execute(text(query))
+            await conn.execute(text(query), params)
             await conn.commit()
 
     async def adelete_nodes(
@@ -467,10 +469,11 @@ class AsyncPostgresVectorStore(BasePydanticVectorStore):
         query = f"""
         SELECT tablename, indexname
         FROM pg_indexes
-        WHERE tablename = '{self._table_name}' AND schemaname = '{self._schema_name}' AND indexname = '{index_name}';
+        WHERE tablename = :table_name AND schemaname = :schema_name AND indexname = :index_name;
         """
+        params = {"table_name": self._table_name, "schema_name": self._schema_name, "index_name": index_name}
         async with self._engine.connect() as conn:
-            result = await conn.execute(text(query))
+            result = await conn.execute(text(query), params)
             result_map = result.mappings()
             results = result_map.fetchall()
         return bool(len(results) == 1)


### PR DESCRIPTION
# Summary

This PR updates query construction to use parameterized values instead of embedding values directly into SQL strings.

Previously, some queries injected values using Python f-strings. This lead to malformed SQL when values contained characters that require escaping (e.g. single quotes in strings). By using query parameters, value escaping and binding are delegated to the database driver.

# Motivation

A concrete example is a value such as:

```python
ref_doc_id = "O'Brien"
```

When embedded directly into a query string, the resulting SQL can become invalid because the single quote terminates the string literal prematurely. This was the case during deletion of nodes from vector and doc stores.

Using parameterized queries allows these values to be handled correctly without manual escaping and reduces the risk of SQL injection vulnerabilities.

# Changes

* Replaced direct value injection with parameterized query arguments.
* Updated affected query execution paths to bind values through the database driver.
* Preserved existing query behavior and query structure.
* Updated `__afetch_query` to accept query params.

# Notes

This change only parameterizes query values.

Table names, column names, and other SQL identifiers are still dynamically constructed where required, as database parameterization mechanisms generally do not support binding identifiers. Existing handling of dynamic identifiers remains unchanged.

# Benefits

* Correctly handles values containing quotes and other special characters.
* Reduces reliance on manual escaping.
* Improves query safety by using the database driver's parameter binding.
* Makes query construction more consistent and maintainable.
